### PR TITLE
Feature/13 bottom nav

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,10 @@
       <map>
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2128623188405797" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.2128623188405797" />
+        <entry key="app/src/main/res/layout/fragment_home_frame.xml" value="0.2128623188405797" />
+        <entry key="app/src/main/res/layout/fragment_locker.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_locker_frame.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_mument_detail.xml" value="0.2128623188405797" />
         <entry key="app/src/main/res/layout/fragment_record.xml" value="0.1" />
         <entry key="app/src/main/res/menu/menu_bottom_navi.xml" value="0.29583333333333334" />
       </map>

--- a/app/src/main/java/com/mument_android/app/presentation/ui/detailcontents/MumentDetailFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/detailcontents/MumentDetailFragment.kt
@@ -1,0 +1,27 @@
+package com.mument_android.app.presentation.ui.detailcontents
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.mument_android.R
+import com.mument_android.app.util.AutoClearedValue
+import com.mument_android.databinding.FragmentMumentDetailBinding
+
+class MumentDetailFragment : Fragment() {
+    private var binding by AutoClearedValue<FragmentMumentDetailBinding>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = FragmentMumentDetailBinding.inflate(inflater, container, false).let {
+        binding = it
+        it.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+}

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFragment.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.mument_android.R
 import com.mument_android.app.presentation.ui.home.viewmodel.HomeViewModel
 import com.mument_android.app.util.AutoClearedValue
 import com.mument_android.databinding.FragmentHomeBinding
@@ -28,6 +30,9 @@ class HomeFragment : Fragment() {
         binding.homeViewModel = viewModel
         binding.emojiTvHome.setOnClickListener {
             viewModel.setRandomTags()
+        }
+        binding.root.setOnClickListener {
+            findNavController().navigate(R.id.action_homeFragment_to_mumentDetailFragment)
         }
     }
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFrameFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFrameFragment.kt
@@ -1,0 +1,26 @@
+package com.mument_android.app.presentation.ui.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.mument_android.app.util.AutoClearedValue
+import com.mument_android.databinding.FragmentHomeFrameBinding
+
+class HomeFrameFragment: Fragment() {
+    private var binding by AutoClearedValue<FragmentHomeFrameBinding>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = FragmentHomeFrameBinding.inflate(inflater, container, false).let {
+        binding = it
+        it.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import com.mument_android.R
 import com.mument_android.app.util.AutoClearedValue
 import com.mument_android.databinding.FragmentLockerBinding
@@ -22,5 +23,8 @@ class LockerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.root.setOnClickListener {
+            findNavController().navigate(R.id.action_lockerFragment_to_mumentDetailFragment)
+        }
     }
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFrameFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFrameFragment.kt
@@ -14,7 +14,6 @@ import com.mument_android.databinding.FragmentLockerFrameBinding
 
 class LockerFrameFragment : Fragment() {
     private var binding by AutoClearedValue<FragmentLockerFrameBinding>()
-    private lateinit var navController: NavController
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,9 +25,6 @@ class LockerFrameFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val navHostFragment = childFragmentManager.findFragmentById(R.id.nav_host_fragment_home_frame) as NavHostFragment
-        navController = navHostFragment.navController
-
     }
 
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFrameFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/locker/LockerFrameFragment.kt
@@ -1,0 +1,34 @@
+package com.mument_android.app.presentation.ui.locker
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.findNavController
+import com.mument_android.R
+import com.mument_android.app.util.AutoClearedValue
+import com.mument_android.databinding.FragmentLockerFrameBinding
+
+class LockerFrameFragment : Fragment() {
+    private var binding by AutoClearedValue<FragmentLockerFrameBinding>()
+    private lateinit var navController: NavController
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = FragmentLockerFrameBinding.inflate(inflater, container, false).let {
+        binding = it
+        it.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val navHostFragment = childFragmentManager.findFragmentById(R.id.nav_host_fragment_home_frame) as NavHostFragment
+        navController = navHostFragment.navController
+
+    }
+
+}

--- a/app/src/main/res/layout/fragment_home_frame.xml
+++ b/app/src/main/res/layout/fragment_home_frame.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_fragment_home_frame"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:navGraph="@navigation/nav_graph_home"
+            app:defaultNavHost="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_locker_frame.xml
+++ b/app/src/main/res/layout/fragment_locker_frame.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".app.presentation.ui.locker.HomeFrameFragment">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_fragment_home_frame"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:navGraph="@navigation/nav_graph_locker"
+            app:defaultNavHost="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_mument_detail.xml
+++ b/app/src/main/res/layout/fragment_mument_detail.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".app.presentation.ui.detailcontents.MumentDetailFragment">
+
+        <!-- TODO: Update blank fragment layout -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="뮤멘트 상세보기" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/menu/menu_bottom_navi.xml
+++ b/app/src/main/res/menu/menu_bottom_navi.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/fragment_home"
+        android:id="@+id/fragment_home_frame"
         android:icon="@drawable/selector_ic_home"
         android:title="@string/bottom_navi_home"/>
 
@@ -11,7 +11,7 @@
         android:title="@string/bottom_navi_record"/>
 
     <item
-        android:id="@+id/fragment_locker"
+        android:id="@+id/fragment_locker_frame"
         android:icon="@drawable/selector_ic_locker"
         android:title="@string/bottom_navi_locker"/>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/fragment_home">
+    app:startDestination="@id/fragment_home_frame">
 
     <fragment
-        android:id="@+id/fragment_home"
-        android:name="com.mument_android.app.presentation.ui.home.HomeFragment"
+        android:id="@+id/fragment_home_frame"
+        android:name="com.mument_android.app.presentation.ui.home.HomeFrameFragment"
         android:label="fragment_first"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_home_frame" />
 
     <fragment
         android:id="@+id/fragment_record"
@@ -18,8 +18,8 @@
         tools:layout="@layout/fragment_record" />
 
     <fragment
-        android:id="@+id/fragment_locker"
-        android:name="com.mument_android.app.presentation.ui.locker.LockerFragment"
+        android:id="@+id/fragment_locker_frame"
+        android:name="com.mument_android.app.presentation.ui.locker.LockerFrameFragment"
         android:label="fragment_third"
-        tools:layout="@layout/fragment_locker" />
+        tools:layout="@layout/fragment_locker_frame" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_home.xml
+++ b/app/src/main/res/navigation/nav_graph_home.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph_home"
+    app:startDestination="@id/homeFragment">
+
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.mument_android.app.presentation.ui.home.HomeFragment"
+        android:label="HomeFragment"
+        tools:layout="@layout/fragment_home">
+        <action
+            android:id="@+id/action_homeFragment_to_mumentDetailFragment"
+            app:destination="@id/mumentDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/mumentDetailFragment"
+        android:name="com.mument_android.app.presentation.ui.detailcontents.MumentDetailFragment"
+        android:label="MumentDetailFragment"
+        tools:layout="@layout/fragment_mument_detail"/>
+
+</navigation>

--- a/app/src/main/res/navigation/nav_graph_locker.xml
+++ b/app/src/main/res/navigation/nav_graph_locker.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph_locker"
+    app:startDestination="@id/lockerFragment">
+
+    <fragment
+        android:id="@+id/lockerFragment"
+        android:name="com.mument_android.app.presentation.ui.locker.LockerFragment"
+        android:label="LockerFragment"
+        tools:layout="@layout/fragment_locker">
+        <action
+            android:id="@+id/action_lockerFragment_to_mumentDetailFragment"
+            app:destination="@id/mumentDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/mumentDetailFragment"
+        android:name="com.mument_android.app.presentation.ui.detailcontents.MumentDetailFragment"
+        android:label="MumentDetailFragment"
+        tools:layout="@layout/fragment_mument_detail"/>
+
+</navigation>


### PR DESCRIPTION
## 🎸 작업한 내용
- BottomNavigation 수정

## 🎶 PR Point
- 상세보기 뷰로 이동시 탭바를 계속 노출시키면서 화면을 전환해야하기 때문에 navigation을 조금 변경하였습니다.
- 기존 하단 탭바 3개 중 HomeFragment.kt / LockerFragment.kt는 각각 HomeFrameFragment.kt / LockerFrameFragment.kt 로 변경하였습니다.
- 변경된 FrameFragment에는 NavHostFragment가 각각 들어가고 해당 HostFragment의 NavController가 그 안에서 navigation을 담당합니다. (말이 어렵네요..ㅋㅋ 프로젝트 열어보면 아실겁니다...!)

### 결과적으로
1️⃣ nav_graph는 탭바를 움직이는 데 사용 
2️⃣ nav_graph_home 은 HomeFrameFragment 내에서 뷰를 움직이는 데 사용
3️⃣ nav_graph_locker는 LockerFrameFragment 내에서 뷰를 움직이는 데 사용

- 더 좋은 구현 방향이 생각 나시면 언제든 말씀해주세요!!


## 📸 스크린샷

## 💽 관련 이슈
- Resolved: #13

