### PR TITLE
[FEAT]#66 record view api

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/GalaxyS10_API_30.avd" />
+            <value value="$USER_HOME$/.android/avd/SampleDevice26.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-07-18T07:50:51.725295Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-07-20T04:16:15.679127Z" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -33,6 +33,9 @@
         <entry key="app/src/main/res/layout/fragment_mument_dialog.xml" value="0.15121580547112462" />
         <entry key="app/src/main/res/layout/fragment_my_like.xml" value="0.2418478260869565" />
         <entry key="app/src/main/res/layout/fragment_record.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_mument_detail.xml" value="0.2128623188405797" />
+        <entry key="app/src/main/res/layout/fragment_mument_dialog.xml" value="0.28489583333333335" />
+        <entry key="app/src/main/res/layout/fragment_record.xml" value="0.2142354563318382" />
         <entry key="app/src/main/res/layout/fragment_record_search.xml" value="0.22554347826086957" />
         <entry key="app/src/main/res/layout/fragment_search.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_song_detail.xml" value="0.21415850400712377" />
@@ -48,6 +51,7 @@
         <entry key="app/src/main/res/layout/item_song_detail_mument.xml" value="0.3128007699711261" />
         <entry key="app/src/main/res/layout/item_tag_checkbox.xml" value="0.7323455810546875" />
         <entry key="app/src/main/res/layout/mument_layout_cardview.xml" value="0.2874231974283854" />
+        <entry key="app/src/main/res/layout/mument_layout_cardview.xml" value="0.1" />
         <entry key="app/src/main/res/menu/menu_bottom_navi.xml" value="0.29583333333333334" />
       </map>
     </option>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         tools:targetApi="31">
         <activity
             android:name=".app.presentation.ui.main.MainActivity"
+            android:windowSoftInputMode="adjustNothing"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/mument_android/app/data/controller/RecordController.kt
+++ b/app/src/main/java/com/mument_android/app/data/controller/RecordController.kt
@@ -1,0 +1,13 @@
+package com.mument_android.app.data.controller
+import com.mument_android.app.data.dto.detail.MumentDetailDto
+import com.mument_android.app.data.dto.record.MumentRecordDto
+import com.mument_android.app.data.dto.record.ResponseRecordMumentDto
+import com.mument_android.app.data.network.base.BaseResponse
+
+interface RecordController {
+    suspend fun recordMument(
+        musicId: String,
+        userId: String,
+        mumentRecordDto: MumentRecordDto
+    ): BaseResponse<ResponseRecordMumentDto>
+}

--- a/app/src/main/java/com/mument_android/app/data/controller/RecordControllerImpl.kt
+++ b/app/src/main/java/com/mument_android/app/data/controller/RecordControllerImpl.kt
@@ -1,0 +1,17 @@
+package com.mument_android.app.data.controller
+
+import com.mument_android.app.data.dto.record.MumentRecordDto
+import com.mument_android.app.data.dto.record.ResponseRecordMumentDto
+import com.mument_android.app.data.network.base.BaseResponse
+import com.mument_android.app.data.network.record.RecordApiService
+import javax.inject.Inject
+
+class RecordControllerImpl @Inject constructor(
+    private val recordApiService: RecordApiService
+): RecordController{
+    override suspend fun recordMument(
+        musicId: String,
+        userId: String,
+        mumentRecordDto: MumentRecordDto
+    ): BaseResponse<ResponseRecordMumentDto> = recordApiService.postMumentRecord(musicId, userId, mumentRecordDto)
+}

--- a/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSource.kt
+++ b/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSource.kt
@@ -3,5 +3,5 @@ package com.mument_android.app.data.datasource.record
 import com.mument_android.app.data.dto.record.MumentIsFirstDto
 
 interface RecordDataSource {
-    suspend fun fetchMumentRecord(userId :String, mumentId: String) : MumentIsFirstDto
+    suspend fun fetchMumentRecord(userId :String, musicId: String) : MumentIsFirstDto
 }

--- a/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSource.kt
+++ b/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSource.kt
@@ -1,4 +1,7 @@
 package com.mument_android.app.data.datasource.record
 
+import com.mument_android.app.data.dto.record.MumentIsFirstDto
+
 interface RecordDataSource {
+    suspend fun fetchMumentRecord(userId :String, mumentId: String) : MumentIsFirstDto
 }

--- a/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSourceImpl.kt
+++ b/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSourceImpl.kt
@@ -1,0 +1,11 @@
+package com.mument_android.app.data.datasource.record
+
+import com.mument_android.app.data.dto.record.MumentIsFirstDto
+import com.mument_android.app.data.network.record.RecordApiService
+import javax.inject.Inject
+
+class RecordDataSourceImpl @Inject constructor(private val recordApiservice: RecordApiService) : RecordDataSource {
+    override suspend fun fetchMumentRecord(userId: String, mumentId: String): MumentIsFirstDto {
+        return recordApiservice.fetchMumentIsFirst(userId,mumentId).data
+    }
+}

--- a/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSourceImpl.kt
+++ b/app/src/main/java/com/mument_android/app/data/datasource/record/RecordDataSourceImpl.kt
@@ -5,7 +5,7 @@ import com.mument_android.app.data.network.record.RecordApiService
 import javax.inject.Inject
 
 class RecordDataSourceImpl @Inject constructor(private val recordApiservice: RecordApiService) : RecordDataSource {
-    override suspend fun fetchMumentRecord(userId: String, mumentId: String): MumentIsFirstDto {
-        return recordApiservice.fetchMumentIsFirst(userId,mumentId).data
+    override suspend fun fetchMumentRecord(userId: String, musicId: String): MumentIsFirstDto {
+        return recordApiservice.fetchMumentIsFirst(userId,musicId).data
     }
 }

--- a/app/src/main/java/com/mument_android/app/data/dto/record/MumentIsFirstDto.kt
+++ b/app/src/main/java/com/mument_android/app/data/dto/record/MumentIsFirstDto.kt
@@ -1,0 +1,6 @@
+package com.mument_android.app.data.dto.record
+
+data class MumentIsFirstDto(
+    val isFirst : Boolean,
+    val FirstAvaliable : Boolean
+)

--- a/app/src/main/java/com/mument_android/app/data/dto/record/MumentRecordDto.kt
+++ b/app/src/main/java/com/mument_android/app/data/dto/record/MumentRecordDto.kt
@@ -1,0 +1,9 @@
+package com.mument_android.app.data.dto.record
+
+data class MumentRecordDto(
+    val content: String,
+    val feelingTag: List<Int>,
+    val impressionTag: List<Int>,
+    val isFirst: Boolean,
+    val isPrivate: Boolean
+)

--- a/app/src/main/java/com/mument_android/app/data/dto/record/ResponseRecordMumentDto.kt
+++ b/app/src/main/java/com/mument_android/app/data/dto/record/ResponseRecordMumentDto.kt
@@ -1,0 +1,8 @@
+package com.mument_android.app.data.dto.record
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseRecordMumentDto(
+    @SerializedName("_id")
+    val id: String
+)

--- a/app/src/main/java/com/mument_android/app/data/mapper/record/RecordMapper.kt
+++ b/app/src/main/java/com/mument_android/app/data/mapper/record/RecordMapper.kt
@@ -1,4 +1,12 @@
 package com.mument_android.app.data.mapper.record
 
-object RecordMapper {
+import com.mument_android.app.data.dto.UserDto
+import com.mument_android.app.data.dto.record.MumentIsFirstDto
+import com.mument_android.app.data.mapper.BaseMapper
+import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
+import com.mument_android.app.domain.entity.user.UserEntity
+
+class RecordMapper : BaseMapper<MumentIsFirstDto, RecordIsFirstEntity> {
+    override fun map(from:MumentIsFirstDto):RecordIsFirstEntity =
+        RecordIsFirstEntity(from.isFirst,from.FirstAvaliable)
 }

--- a/app/src/main/java/com/mument_android/app/data/network/record/RecordApiService.kt
+++ b/app/src/main/java/com/mument_android/app/data/network/record/RecordApiService.kt
@@ -1,16 +1,25 @@
 package com.mument_android.app.data.network.record
 
 import com.mument_android.app.data.dto.record.MumentIsFirstDto
+import com.mument_android.app.data.dto.record.MumentRecordDto
+import com.mument_android.app.data.dto.record.ResponseRecordMumentDto
 import com.mument_android.app.data.network.base.BaseResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface RecordApiService {
     @GET("/mument/{userId}/{musicId}/is-first")
     suspend fun fetchMumentIsFirst(
         @Path("userId") userId : String,
-        @Path("musicId") mumentId : String
+        @Path("musicId") musicId : String
     ) : BaseResponse<MumentIsFirstDto>
 
-
+    @POST("/mument/{userId}/{musicId}")
+    suspend fun postMumentRecord(
+        @Path("musicId") musicId : String,
+        @Path("userId") userId : String,
+        @Body mumentRecordDto: MumentRecordDto
+    ) : BaseResponse<ResponseRecordMumentDto>
 }

--- a/app/src/main/java/com/mument_android/app/data/network/record/RecordApiService.kt
+++ b/app/src/main/java/com/mument_android/app/data/network/record/RecordApiService.kt
@@ -1,0 +1,16 @@
+package com.mument_android.app.data.network.record
+
+import com.mument_android.app.data.dto.record.MumentIsFirstDto
+import com.mument_android.app.data.network.base.BaseResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface RecordApiService {
+    @GET("/mument/{userId}/{musicId}/is-first")
+    suspend fun fetchMumentIsFirst(
+        @Path("userId") userId : String,
+        @Path("musicId") mumentId : String
+    ) : BaseResponse<MumentIsFirstDto>
+
+
+}

--- a/app/src/main/java/com/mument_android/app/data/network/record/RecordNetwork.kt
+++ b/app/src/main/java/com/mument_android/app/data/network/record/RecordNetwork.kt
@@ -1,4 +1,0 @@
-package com.mument_android.app.data.network.record
-
-interface RecordNetwork {
-}

--- a/app/src/main/java/com/mument_android/app/data/repository/RecordRepositoryImpl.kt
+++ b/app/src/main/java/com/mument_android/app/data/repository/RecordRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.mument_android.app.data.repository
+
+import com.mument_android.app.data.datasource.record.RecordDataSource
+import com.mument_android.app.data.mapper.record.RecordMapper
+import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
+import com.mument_android.app.domain.repository.record.RecordRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class RecordRepositoryImpl @Inject constructor(
+    private val recordDataSource: RecordDataSource,
+    private val recordMapper: RecordMapper
+) : RecordRepository {
+    override suspend fun fetchMumentRecord(
+        userId: String,
+        mumentId: String
+    ): Flow<RecordIsFirstEntity> = flow {
+        emit(recordMapper.map(recordDataSource.fetchMumentRecord(userId, mumentId)))
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/mument_android/app/data/repository/RecordRepositoryImpl.kt
+++ b/app/src/main/java/com/mument_android/app/data/repository/RecordRepositoryImpl.kt
@@ -16,8 +16,8 @@ class RecordRepositoryImpl @Inject constructor(
 ) : RecordRepository {
     override suspend fun fetchMumentRecord(
         userId: String,
-        mumentId: String
+        musicId: String
     ): Flow<RecordIsFirstEntity> = flow {
-        emit(recordMapper.map(recordDataSource.fetchMumentRecord(userId, mumentId)))
+        emit(recordMapper.map(recordDataSource.fetchMumentRecord(userId, musicId)))
     }.flowOn(Dispatchers.IO)
 }

--- a/app/src/main/java/com/mument_android/app/di/ControllerModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/ControllerModule.kt
@@ -2,7 +2,10 @@ package com.mument_android.app.di
 
 import com.mument_android.app.data.controller.LikeMumentController
 import com.mument_android.app.data.controller.LikeMumentControllerImpl
+import com.mument_android.app.data.controller.RecordController
+import com.mument_android.app.data.controller.RecordControllerImpl
 import com.mument_android.app.data.network.main.MainApiService
+import com.mument_android.app.data.network.record.RecordApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +20,11 @@ object ControllerModule {
     @Singleton
     fun provideLikeMumentController(mainApiService: MainApiService): LikeMumentController =
         LikeMumentControllerImpl(mainApiService)
+
+    @Provides
+    @Singleton
+    fun providesRecordController(
+        recordApiService: RecordApiService
+    ): RecordController = RecordControllerImpl(recordApiService)
 
 }

--- a/app/src/main/java/com/mument_android/app/di/DataSourceModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/DataSourceModule.kt
@@ -8,6 +8,8 @@ import com.mument_android.app.data.datasource.detail.MumentDetailDataSourceImpl
 import com.mument_android.app.data.datasource.home.*
 import com.mument_android.app.data.datasource.locker.LockerDataSource
 import com.mument_android.app.data.datasource.locker.LockerDataSourceImpl
+import com.mument_android.app.data.datasource.record.RecordDataSource
+import com.mument_android.app.data.datasource.record.RecordDataSourceImpl
 import com.mument_android.app.data.local.converter.DateTypeConverter
 import com.mument_android.app.data.local.converter.IntListTypeConverter
 import com.mument_android.app.data.local.converter.MusicTypeConverter
@@ -17,6 +19,7 @@ import com.mument_android.app.data.local.todaymument.MumentDatabase
 import com.mument_android.app.data.local.todaymument.TodayMumentDAO
 import com.mument_android.app.data.network.detail.DetailApiService
 import com.mument_android.app.data.network.locker.LockerNetwork
+import com.mument_android.app.data.network.record.RecordApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,6 +37,11 @@ object DataSourceModule {
     fun provideGson(): Gson {
         return Gson()
     }
+
+    @Provides
+    @Singleton
+    fun provideIsFirstDataSource(recordApiService: RecordApiService): RecordDataSource =
+        RecordDataSourceImpl(recordApiService)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/mument_android/app/di/MapperModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/MapperModule.kt
@@ -6,6 +6,7 @@ import com.mument_android.app.data.mapper.locker.LockerMapper
 import com.mument_android.app.data.mapper.main.EmotionalTagMapper
 import com.mument_android.app.data.mapper.main.ImpressiveTagMapper
 import com.mument_android.app.data.mapper.main.IsFirstTagMapper
+import com.mument_android.app.data.mapper.record.RecordMapper
 import com.mument_android.app.data.mapper.user.UserMapper
 import dagger.Module
 import dagger.Provides
@@ -36,6 +37,10 @@ object MapperModule {
     @Provides
     @Singleton
     fun provideIsFirstTagMapper(): IsFirstTagMapper = IsFirstTagMapper()
+
+    @Provides
+    @Singleton
+    fun provideRecordMapper(): RecordMapper = RecordMapper()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import com.mument_android.BuildConfig
 import com.mument_android.app.data.network.detail.DetailApiService
 import com.mument_android.app.data.network.locker.LockerNetwork
 import com.mument_android.app.data.network.main.MainApiService
+import com.mument_android.app.data.network.record.RecordApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,7 +37,7 @@ object NetworkModule {
     @Singleton
     fun provideUnAuthRetrofit(okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
-            .baseUrl(BuildConfig.BASE_URL)
+            .baseUrl("http://15.164.129.17:8000")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
@@ -44,6 +45,10 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideDetailApiService(retrofit: Retrofit): DetailApiService = retrofit.create(DetailApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideRecordApiService(retrofit: Retrofit): RecordApiService = retrofit.create(RecordApiService::class.java)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
@@ -37,7 +37,7 @@ object NetworkModule {
     @Singleton
     fun provideUnAuthRetrofit(okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
-            .baseUrl("http://15.164.129.17:8000")
+            .baseUrl(BuildConfig.BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/app/src/main/java/com/mument_android/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/RepositoryModule.kt
@@ -4,14 +4,18 @@ import com.mument_android.app.data.datasource.detail.MumentDetailDataSource
 import com.mument_android.app.data.datasource.home.RecentSearchListDataSource
 import com.mument_android.app.data.datasource.home.TodayMumentDataSource
 import com.mument_android.app.data.datasource.locker.LockerDataSource
+import com.mument_android.app.data.datasource.record.RecordDataSource
 import com.mument_android.app.data.mapper.detail.MumentDetailMapper
 import com.mument_android.app.data.mapper.locker.LockerMapper
+import com.mument_android.app.data.mapper.record.RecordMapper
 import com.mument_android.app.data.repository.HomeRepositoryImpl
 import com.mument_android.app.data.repository.LockerRepositoryImpl
 import com.mument_android.app.data.repository.MumentDetailRepositoryImpl
+import com.mument_android.app.data.repository.RecordRepositoryImpl
 import com.mument_android.app.domain.repository.detail.MumentDetailRepository
 import com.mument_android.app.domain.repository.home.HomeRepository
 import com.mument_android.app.domain.repository.locker.LockerRepository
+import com.mument_android.app.domain.repository.record.RecordRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,6 +40,14 @@ object RepositoryModule {
         lockerMapper: LockerMapper,
         lockerDataSource: LockerDataSource
     ): LockerRepository = LockerRepositoryImpl(lockerMapper, lockerDataSource)
+
+    @Provides
+    @Singleton
+    fun provideRecordRepository(
+        recordMapper: RecordMapper,
+        recordDataSource: RecordDataSource
+    ): RecordRepository = RecordRepositoryImpl(recordDataSource, recordMapper)
+
 
 
     @Provides

--- a/app/src/main/java/com/mument_android/app/di/UseCaseModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/UseCaseModule.kt
@@ -5,6 +5,7 @@ import com.mument_android.app.data.controller.LikeMumentControllerImpl
 import com.mument_android.app.domain.repository.detail.MumentDetailRepository
 import com.mument_android.app.domain.repository.home.HomeRepository
 import com.mument_android.app.domain.repository.locker.LockerRepository
+import com.mument_android.app.domain.repository.record.RecordRepository
 import com.mument_android.app.domain.usecase.detail.FetchMumentDetailContentUseCase
 import com.mument_android.app.domain.usecase.detail.FetchMumentDetailContentUseCaseImpl
 import com.mument_android.app.domain.usecase.home.CRURecentSearchListUseCase
@@ -17,6 +18,8 @@ import com.mument_android.app.domain.usecase.main.CancelLikeMumentUseCase
 import com.mument_android.app.domain.usecase.main.CancelLikeMumentUseCaseImpl
 import com.mument_android.app.domain.usecase.main.LikeMumentUseCase
 import com.mument_android.app.domain.usecase.main.LikeMumentUseCaseImpl
+import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCase
+import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCaseImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,6 +33,11 @@ object UseCaseModule {
     @Singleton
     fun provideFetchMumentDetailContentUseCase(mumentDetailRepository: MumentDetailRepository): FetchMumentDetailContentUseCase =
         FetchMumentDetailContentUseCaseImpl(mumentDetailRepository)
+
+    @Provides
+    @Singleton
+    fun provideIsFirstRecordMumentUseCase(recordRepository: RecordRepository): IsFirstRecordMumentUseCase =
+        IsFirstRecordMumentUseCaseImpl(recordRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/mument_android/app/di/UseCaseModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.mument_android.app.di
 
 import com.mument_android.app.data.controller.LikeMumentController
 import com.mument_android.app.data.controller.LikeMumentControllerImpl
+import com.mument_android.app.data.controller.RecordController
 import com.mument_android.app.domain.repository.detail.MumentDetailRepository
 import com.mument_android.app.domain.repository.home.HomeRepository
 import com.mument_android.app.domain.repository.locker.LockerRepository
@@ -20,6 +21,8 @@ import com.mument_android.app.domain.usecase.main.LikeMumentUseCase
 import com.mument_android.app.domain.usecase.main.LikeMumentUseCaseImpl
 import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCase
 import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCaseImpl
+import com.mument_android.app.domain.usecase.record.RecordMumentUseCase
+import com.mument_android.app.domain.usecase.record.RecordMumentUseCaseImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -65,5 +68,12 @@ object UseCaseModule {
     @Singleton
     fun provideDeleteRecentSearchListUseCase(homeRepository: HomeRepository): DeleteRecentSearchListUseCase =
         DeleteRecentSearchListUseCaseImpl(homeRepository)
+
+    @Provides
+    @Singleton
+    fun provideRecordMumentUseCase(
+        recordController: RecordController
+    ): RecordMumentUseCase = RecordMumentUseCaseImpl(recordController)
+
 
 }

--- a/app/src/main/java/com/mument_android/app/domain/entity/record/RecordIsFirstEntity.kt
+++ b/app/src/main/java/com/mument_android/app/domain/entity/record/RecordIsFirstEntity.kt
@@ -1,0 +1,6 @@
+package com.mument_android.app.domain.entity.record
+
+data class RecordIsFirstEntity(
+    val isFirst : Boolean,
+    val FirstAvaliable : Boolean
+)

--- a/app/src/main/java/com/mument_android/app/domain/repository/record/RecordRepository.kt
+++ b/app/src/main/java/com/mument_android/app/domain/repository/record/RecordRepository.kt
@@ -4,5 +4,5 @@ import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
 import kotlinx.coroutines.flow.Flow
 
 interface RecordRepository {
-    suspend fun fetchMumentRecord(userId : String, mumentId:String) : Flow<RecordIsFirstEntity>
+    suspend fun fetchMumentRecord(userId : String, musicId:String) : Flow<RecordIsFirstEntity>
 }

--- a/app/src/main/java/com/mument_android/app/domain/repository/record/RecordRepository.kt
+++ b/app/src/main/java/com/mument_android/app/domain/repository/record/RecordRepository.kt
@@ -1,4 +1,8 @@
 package com.mument_android.app.domain.repository.record
 
+import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
+import kotlinx.coroutines.flow.Flow
+
 interface RecordRepository {
+    suspend fun fetchMumentRecord(userId : String, mumentId:String) : Flow<RecordIsFirstEntity>
 }

--- a/app/src/main/java/com/mument_android/app/domain/usecase/detail/FetchMumentDetailContentUseCase.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/detail/FetchMumentDetailContentUseCase.kt
@@ -1,6 +1,5 @@
 package com.mument_android.app.domain.usecase.detail
 
-import com.mument_android.app.data.network.util.ApiResult
 import com.mument_android.app.domain.entity.detail.MumentDetailEntity
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCase.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCase.kt
@@ -1,0 +1,8 @@
+package com.mument_android.app.domain.usecase.record
+
+import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
+import kotlinx.coroutines.flow.Flow
+
+interface IsFirstRecordMumentUseCase {
+    suspend operator fun invoke(userId: String, mumentId: String): Flow<RecordIsFirstEntity>
+}

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCase.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCase.kt
@@ -4,5 +4,5 @@ import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
 import kotlinx.coroutines.flow.Flow
 
 interface IsFirstRecordMumentUseCase {
-    suspend operator fun invoke(userId: String, mumentId: String): Flow<RecordIsFirstEntity>
+    suspend operator fun invoke(userId: String, musicId: String): Flow<RecordIsFirstEntity>
 }

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCaseImpl.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.mument_android.app.domain.usecase.record
+
+import com.mument_android.app.domain.entity.record.RecordIsFirstEntity
+import com.mument_android.app.domain.repository.record.RecordRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class IsFirstRecordMumentUseCaseImpl @Inject constructor(
+    private val recordRepository: RecordRepository
+) : IsFirstRecordMumentUseCase {
+    override suspend operator fun invoke(
+        userId: String,
+        mumentId: String
+    ): Flow<RecordIsFirstEntity> =
+        recordRepository.fetchMumentRecord(userId, mumentId)
+}
+

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCaseImpl.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/IsFirstRecordMumentUseCaseImpl.kt
@@ -10,8 +10,8 @@ class IsFirstRecordMumentUseCaseImpl @Inject constructor(
 ) : IsFirstRecordMumentUseCase {
     override suspend operator fun invoke(
         userId: String,
-        mumentId: String
+        musicId: String
     ): Flow<RecordIsFirstEntity> =
-        recordRepository.fetchMumentRecord(userId, mumentId)
+        recordRepository.fetchMumentRecord(userId, musicId)
 }
 

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordMumentUseCase.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordMumentUseCase.kt
@@ -1,0 +1,12 @@
+package com.mument_android.app.domain.usecase.record
+
+import com.mument_android.app.data.dto.record.MumentRecordDto
+import kotlinx.coroutines.flow.Flow
+
+interface RecordMumentUseCase {
+    suspend operator fun invoke(
+        musicId: String,
+        userId: String,
+        mumentRecordDto: MumentRecordDto
+    ): Flow<String>
+}

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordMumentUseCaseImpl.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordMumentUseCaseImpl.kt
@@ -1,0 +1,22 @@
+package com.mument_android.app.domain.usecase.record
+
+import com.mument_android.app.data.controller.LikeMumentController
+import com.mument_android.app.data.controller.RecordController
+import com.mument_android.app.data.dto.record.MumentRecordDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class RecordMumentUseCaseImpl @Inject constructor(
+    private val recordController: RecordController
+): RecordMumentUseCase {
+    override suspend fun invoke(
+        musicId: String,
+        userId: String,
+        mumentRecordDto: MumentRecordDto
+    ): Flow<String> = flow {
+        emit(recordController.recordMument(musicId, userId, mumentRecordDto).data.id)
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordTestUseCase.kt
+++ b/app/src/main/java/com/mument_android/app/domain/usecase/record/RecordTestUseCase.kt
@@ -1,5 +1,0 @@
-package com.mument_android.app.domain.usecase.record
-
-class RecordTestUseCase {
-    //빈 패키지 방지를 위한 test class
-}

--- a/app/src/main/java/com/mument_android/app/presentation/ui/customview/MumentDialog.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/customview/MumentDialog.kt
@@ -14,7 +14,8 @@ class MumentDialog(
     private val header: String?,
     private val body: String?,
     private val allowListener: (() -> Unit)?,
-    private val cancelListener: (() -> Unit)?
+    private val cancelListener: (() -> Unit)?,
+    private val option: Boolean
 ): DialogFragment() {
     private var binding by AutoClearedValue<FragmentMumentDialogBinding>()
 
@@ -38,6 +39,7 @@ class MumentDialog(
         super.onViewCreated(view, savedInstanceState)
         binding.tvHeader.setContent(header)
         binding.tvBody.setContent(body)
+        binding.tvAllow.text = if(option) "확인" else "삭제"
         setClickListener()
     }
 

--- a/app/src/main/java/com/mument_android/app/presentation/ui/customview/MumentDialogBuilder.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/customview/MumentDialogBuilder.kt
@@ -5,9 +5,10 @@ class MumentDialogBuilder {
     private var body: String? = null
     private var allowListener: (() -> Unit)? = null
     private var cancelListener: (() -> Unit)? = null
+    private var option: Boolean = false
 
     fun build(): MumentDialog {
-        return MumentDialog(header, body, allowListener, cancelListener)
+        return MumentDialog(header, body, allowListener, cancelListener, option)
     }
 
     fun setHeader(header: String): MumentDialogBuilder {
@@ -29,4 +30,11 @@ class MumentDialogBuilder {
         cancelListener = listener
         return this
     }
+
+
+    fun setOption(option: Boolean): MumentDialogBuilder {
+        this.option = option
+        return this
+    }
+
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
@@ -18,7 +18,10 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.mument_android.R
 import com.mument_android.app.data.local.recentlist.RecentSearchData
 import com.mument_android.app.data.network.home.adapter.SearchListAdapter
+<<<<<<< HEAD
 import com.mument_android.app.data.network.util.ApiResult
+=======
+>>>>>>> 778d4b0 (Mument Dialog 수정)
 import com.mument_android.app.presentation.ui.home.viewmodel.SearchViewModel
 import com.mument_android.app.presentation.ui.main.MainActivity
 import com.mument_android.app.util.AutoClearedValue
@@ -27,9 +30,14 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+<<<<<<< HEAD
 class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> Unit) :
     BottomSheetDialogFragment() {
     private val viewmodel: SearchViewModel by activityViewModels()
+=======
+class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> Unit) : BottomSheetDialogFragment() {
+    private val viewmodel: SearchViewModel by viewModels()
+>>>>>>> 778d4b0 (Mument Dialog 수정)
     private lateinit var adapter: SearchListAdapter
     private var binding by AutoClearedValue<FragmentSearchBinding>()
     private lateinit var behavior: BottomSheetBehavior<View>
@@ -40,10 +48,16 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
 
         @JvmStatic
         fun newInstance(contentClick: (RecentSearchData) -> Unit): BottomSheetSearchFragment {
+<<<<<<< HEAD
             return INSTANCE
                 ?: BottomSheetSearchFragment(contentClick = { contentClick(it) }).apply {
                     INSTANCE = this
                 }
+=======
+            return INSTANCE ?: BottomSheetSearchFragment(contentClick = { contentClick(it) }).apply {
+                INSTANCE = this
+            }
+>>>>>>> 778d4b0 (Mument Dialog 수정)
         }
     }
 
@@ -82,10 +96,18 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+<<<<<<< HEAD
         adapter = SearchListAdapter(requireContext(), { data ->
             viewmodel.selectContent(data)
         }, { data ->
             viewmodel.deleteRecentList(data)
+=======
+        adapter = SearchListAdapter(requireContext(),{
+            contentClick(it)
+            dismiss()
+        }, {
+
+>>>>>>> 778d4b0 (Mument Dialog 수정)
         })
         /*searchResultAdapter = SearchListAdapter(requireContext(),{ data ->
             viewmodel.selectContent(data)

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
@@ -84,7 +84,7 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        adapter = SearchListAdapter(requireContext(),{
+        adapter = SearchListAdapter(requireContext(), {
             contentClick(it)
             dismiss()
         }, {
@@ -151,36 +151,23 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
                         }
                     }
                 }
-            lifecycleScope.launch {
-
-                viewmodel.searchList.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect {
-                    when (it) {
-                        is ApiResult.Loading -> {}
-                        is ApiResult.Failure -> {}
-                        is ApiResult.Success -> {
-                            adapter.submitList(it.data)
-                        }
-                        else -> {
-
-                        }
-                    }
-                }
-
-            }
         }
 
-        private fun getBottomSheetDialogDefaultHeight(): Int {
-            return getWindowHeight() * 80 / 100
-        }
 
-        private fun getWindowHeight(): Int {
-            // Calculate window height for fullscreen use
-            val windowMetrics: WindowMetrics = WindowMetricsCalculator.getOrCreate()
-                .computeCurrentWindowMetrics((activity as MainActivity))
-            val pxHeight = windowMetrics.bounds.height()
-            return pxHeight
-        }
 
     }
+
+    private fun getBottomSheetDialogDefaultHeight(): Int {
+        return getWindowHeight() * 80 / 100
+    }
+
+    private fun getWindowHeight(): Int {
+        // Calculate window height for fullscreen use
+        val windowMetrics: WindowMetrics = WindowMetricsCalculator.getOrCreate()
+            .computeCurrentWindowMetrics((activity as MainActivity))
+        val pxHeight = windowMetrics.bounds.height()
+        return pxHeight
+    }
+}
 
 

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/BottomSheetSearchFragment.kt
@@ -18,10 +18,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.mument_android.R
 import com.mument_android.app.data.local.recentlist.RecentSearchData
 import com.mument_android.app.data.network.home.adapter.SearchListAdapter
-<<<<<<< HEAD
 import com.mument_android.app.data.network.util.ApiResult
-=======
->>>>>>> 778d4b0 (Mument Dialog 수정)
 import com.mument_android.app.presentation.ui.home.viewmodel.SearchViewModel
 import com.mument_android.app.presentation.ui.main.MainActivity
 import com.mument_android.app.util.AutoClearedValue
@@ -30,14 +27,9 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-<<<<<<< HEAD
 class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> Unit) :
     BottomSheetDialogFragment() {
     private val viewmodel: SearchViewModel by activityViewModels()
-=======
-class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> Unit) : BottomSheetDialogFragment() {
-    private val viewmodel: SearchViewModel by viewModels()
->>>>>>> 778d4b0 (Mument Dialog 수정)
     private lateinit var adapter: SearchListAdapter
     private var binding by AutoClearedValue<FragmentSearchBinding>()
     private lateinit var behavior: BottomSheetBehavior<View>
@@ -48,16 +40,11 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
 
         @JvmStatic
         fun newInstance(contentClick: (RecentSearchData) -> Unit): BottomSheetSearchFragment {
-<<<<<<< HEAD
             return INSTANCE
                 ?: BottomSheetSearchFragment(contentClick = { contentClick(it) }).apply {
                     INSTANCE = this
                 }
-=======
-            return INSTANCE ?: BottomSheetSearchFragment(contentClick = { contentClick(it) }).apply {
-                INSTANCE = this
-            }
->>>>>>> 778d4b0 (Mument Dialog 수정)
+
         }
     }
 
@@ -96,18 +83,13 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-<<<<<<< HEAD
-        adapter = SearchListAdapter(requireContext(), { data ->
-            viewmodel.selectContent(data)
-        }, { data ->
-            viewmodel.deleteRecentList(data)
-=======
+
         adapter = SearchListAdapter(requireContext(),{
             contentClick(it)
             dismiss()
         }, {
 
->>>>>>> 778d4b0 (Mument Dialog 수정)
+
         })
         /*searchResultAdapter = SearchListAdapter(requireContext(),{ data ->
             viewmodel.selectContent(data)
@@ -116,6 +98,21 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
         binding.viewmodel = viewmodel
         binding.option = false
         binding.rcSearch.adapter = adapter
+        adapter = SearchListAdapter(requireContext(), {
+            contentClick(it)
+            dismiss()
+        }, {
+            viewmodel.deleteRecentList(it)
+        })
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewmodel = viewmodel
+        binding.rcSearch.adapter = adapter
+
+        binding.option = false
+        setListener()
+    }
+
+    private fun setListener() {
 
         binding.etSearch.setOnEditorActionListener { edit, actionId, keyEvent ->
             if (actionId == EditorInfo.IME_ACTION_DONE) {
@@ -154,20 +151,36 @@ class BottomSheetSearchFragment(private val contentClick: (RecentSearchData) -> 
                         }
                     }
                 }
+            lifecycleScope.launch {
+
+                viewmodel.searchList.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collect {
+                    when (it) {
+                        is ApiResult.Loading -> {}
+                        is ApiResult.Failure -> {}
+                        is ApiResult.Success -> {
+                            adapter.submitList(it.data)
+                        }
+                        else -> {
+
+                        }
+                    }
+                }
+
+            }
         }
+
+        private fun getBottomSheetDialogDefaultHeight(): Int {
+            return getWindowHeight() * 80 / 100
+        }
+
+        private fun getWindowHeight(): Int {
+            // Calculate window height for fullscreen use
+            val windowMetrics: WindowMetrics = WindowMetricsCalculator.getOrCreate()
+                .computeCurrentWindowMetrics((activity as MainActivity))
+            val pxHeight = windowMetrics.bounds.height()
+            return pxHeight
+        }
+
     }
 
-    private fun getBottomSheetDialogDefaultHeight(): Int {
-        return getWindowHeight() * 80 / 100
-    }
 
-    private fun getWindowHeight(): Int {
-        // Calculate window height for fullscreen use
-        val windowMetrics: WindowMetrics = WindowMetricsCalculator.getOrCreate()
-            .computeCurrentWindowMetrics((activity as MainActivity))
-        val pxHeight = windowMetrics.bounds.height()
-        return pxHeight
-    }
-
-
-}

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/HomeFragment.kt
@@ -53,7 +53,7 @@ class HomeFragment : Fragment() {
             findNavController().navigate(R.id.action_homeFragment_to_mumentDetailFragment)
         }
         binding.tvSearch.setOnClickListener {
-            findNavController().navigate(R.id.action_homeFragment_to_mumentHistoryFragment)
+            findNavController().navigate(R.id.action_homeFragment_to_searchFragment)
             /*BottomSheetSearchFragment.newInstance().show(childFragmentManager, "Search")*/
         }
     }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/SearchFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/SearchFragment.kt
@@ -113,6 +113,10 @@ class SearchFragment : Fragment() {
                         }
                     }
                 }
+                else -> {
+
+                }
+            }
         }
         /*
             viewmodel.searchList.launchWhenCreated(viewLifecycleOwner.lifecycleScope) { result ->
@@ -125,9 +129,3 @@ class SearchFragment : Fragment() {
                 }
             }*/
     }
-
-    override fun onStop() {
-        super.onStop()
-        viewmodel.searchResultList.value = listOf()
-    }
-}

--- a/app/src/main/java/com/mument_android/app/presentation/ui/home/SearchFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/home/SearchFragment.kt
@@ -113,9 +113,7 @@ class SearchFragment : Fragment() {
                         }
                     }
                 }
-                else -> {
 
-                }
             }
         }
         /*

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -265,7 +265,7 @@ class RecordFragment : Fragment() {
         MumentDialogBuilder()
             .setHeader(getString(R.string.record_reset_header))
             .setBody(getString(R.string.record_reset_body))
-            .setOption(false)
+            .setOption(true)
             .setAllowListener {
                 resetRecord()
                 resetRecordTags()
@@ -282,8 +282,6 @@ class RecordFragment : Fragment() {
         binding.btnRecordFirst.isChangeButtonFont(false)
         binding.btnRecordSecond.isChangeButtonFont(false)
         binding.btnRecordFirst.isEnabled = true
-        recordViewModel.checkIsFirst(true)
-
         binding.clRecordRoot.scrollTo(0, 0)
         binding.etRecordWrite.text.clear()
 
@@ -308,7 +306,6 @@ class RecordFragment : Fragment() {
                 recordViewModel.changeSelectedMusic(it)
                 recordViewModel.findIsFirst()
             }.show(parentFragmentManager, "bottom sheet")
-            recordViewModel.checkSelectedMusic(true)
             Timber.d(recordViewModel.selectedMusic.value.toString())
         }
         recordViewModel.selectedMusic.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -251,6 +251,7 @@ class RecordFragment : Fragment() {
         MumentDialogBuilder()
             .setHeader(getString(R.string.record_reset_header))
             .setBody(getString(R.string.record_reset_body))
+            .setOption(false)
             .setAllowListener {
                 resetRecord()
                 resetRecordTags()

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -40,7 +40,6 @@ class RecordFragment : Fragment() {
     private val recordViewModel: RecordViewModel by viewModels()
     private lateinit var rvImpressionTagsAdapter: RecordTagAdapter
     private lateinit var rvEmotionalTagsAdapter: RecordTagAdapter
-    private val searchViewModel: SearchViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -183,7 +182,6 @@ class RecordFragment : Fragment() {
 
     private fun observingListen() {
         recordViewModel.isFirst.observe(viewLifecycleOwner) {
-            Timber.d("collect!@!@ $it")
             if (!it) {
                 binding.btnRecordFirst.isChangeButtonFont(it)
                 binding.btnRecordSecond.isChangeButtonFont(!it)
@@ -210,7 +208,6 @@ class RecordFragment : Fragment() {
             binding.btnRecordSecond.setOnClickListener {
                 btnRecordFirst.isChangeButtonFont(false)
                 btnRecordSecond.isChangeButtonFont(true)
-
             }
         }
     }
@@ -247,7 +244,7 @@ class RecordFragment : Fragment() {
     }
 
     private fun countText() {
-        recordViewModel.text.observe(viewLifecycleOwner) {
+        recordViewModel.mumentContent.observe(viewLifecycleOwner) {
             if (it.length >= 1000) {
                 binding.tvRecordTextNum.isChangeRedLine()
             } else if (it.length == 999) {
@@ -318,14 +315,7 @@ class RecordFragment : Fragment() {
 
     private fun getAllData() {
         binding.btnRecordFinish.setOnClickListener {
-
-            Timber.e(
-                "버튼 : ${binding.btnRecordFirst.isSelected}\n 태그 : ${
-                    rvImpressionTagsAdapter.selectedTags.map {
-                        it.tagIdx
-                    }
-                }\n 감상기록 : ${recordViewModel.text.value}\n 공개글 : ${binding.switchRecordSecret.isChecked}"
-            )
+            recordViewModel.postMument()
         }
     }
 
@@ -336,11 +326,6 @@ class RecordFragment : Fragment() {
             binding.btnRecordFirst.isEnabled =true
             binding.btnRecordFirst.isChangeButtonFont(false)
             binding.btnRecordSecond.isChangeButtonFont(false)
-
         }
     }
-
-
-
-
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -31,9 +31,10 @@ import com.mument_android.app.util.RecyclerviewItemDivider.Companion.IS_GRIDLAYO
 import com.mument_android.app.util.ViewUtils.dpToPx
 import com.mument_android.app.util.ViewUtils.snackBar
 import com.mument_android.databinding.FragmentRecordBinding
+import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
-
+@AndroidEntryPoint
 class RecordFragment : Fragment() {
     private var binding by AutoClearedValue<FragmentRecordBinding>()
     private val recordViewModel: RecordViewModel by viewModels()
@@ -63,7 +64,7 @@ class RecordFragment : Fragment() {
         initBottomSheet()
         getAllData()
         isClickDelete()
-
+        observingListen()
     }
 
     private fun setTagRecyclerView() {
@@ -180,6 +181,13 @@ class RecordFragment : Fragment() {
         }
     }
 
+    private fun observingListen() {
+        recordViewModel.isFirst.observe(viewLifecycleOwner) {
+            binding.btnRecordFirst.isChangeButtonFont(it)
+            binding.btnRecordSecond.isChangeButtonFont(!it)
+        }
+    }
+
     private fun firstListenClickEvent() {
         binding.btnRecordFirst.isChangeButtonFont(true)
         with(binding) {
@@ -290,9 +298,9 @@ class RecordFragment : Fragment() {
     private fun initBottomSheet() {
         binding.btnRecordSearch.setOnClickListener {
             BottomSheetSearchFragment.newInstance {
-//                recordViewModel.changeSelectedMusic(it)
+                recordViewModel.changeSelectedMusic(it)
             }.show(parentFragmentManager, "bottom sheet")
-//            recordViewModel.checkSelectedMusic(true)
+            recordViewModel.checkSelectedMusic(true)
             Timber.d(recordViewModel.selectedMusic.value.toString())
         }
         recordViewModel.selectedMusic.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -185,20 +185,27 @@ class RecordFragment : Fragment() {
             if (!it) {
                 binding.btnRecordFirst.isChangeButtonFont(it)
                 binding.btnRecordSecond.isChangeButtonFont(!it)
-                binding.btnRecordFirst.isEnabled = false
-            }
-            else{
+                binding.btnRecordFirst.isClickable = false
+            } else {
                 binding.btnRecordFirst.isChangeButtonFont(!it)
                 binding.btnRecordSecond.isChangeButtonFont(it)
             }
+
         }
     }
 
     private fun firstListenClickEvent() {
         with(binding) {
             btnRecordFirst.setOnClickListener {
-                btnRecordFirst.isChangeButtonFont(true)
-                btnRecordSecond.isChangeButtonFont(false)
+                    btnRecordFirst.isChangeButtonFont(true)
+                    btnRecordSecond.isChangeButtonFont(false)
+            }
+            btnRecordFirst.setOnTouchListener { view, motionEvent ->
+
+                if (!binding.btnRecordFirst.isClickable) {
+                    requireContext().snackBar(binding.clRecordRoot, "Hi")
+                }
+                false
             }
         }
     }
@@ -278,7 +285,7 @@ class RecordFragment : Fragment() {
 
         binding.btnRecordFirst.isChangeButtonFont(false)
         binding.btnRecordSecond.isChangeButtonFont(false)
-        binding.btnRecordFirst.isEnabled = true
+        binding.btnRecordFirst.isClickable = true
         binding.clRecordRoot.scrollTo(0, 0)
         binding.etRecordWrite.text.clear()
 
@@ -323,7 +330,7 @@ class RecordFragment : Fragment() {
         binding.ivDelete.setOnClickListener {
             recordViewModel.checkSelectedMusic(false)
             recordViewModel.removeSelectedMusic()
-            binding.btnRecordFirst.isEnabled =true
+            binding.btnRecordFirst.isClickable = true
             binding.btnRecordFirst.isChangeButtonFont(false)
             binding.btnRecordSecond.isChangeButtonFont(false)
         }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -267,7 +267,7 @@ class RecordFragment : Fragment() {
 
         binding.btnRecordFirst.isChangeButtonFont(true)
         binding.btnRecordSecond.isChangeButtonFont(false)
-        recordViewModel!!.checkIsFirst(true)
+        recordViewModel.checkIsFirst(true)
 
         binding.clRecordRoot.scrollTo(0, 0)
         binding.etRecordWrite.text.clear()

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -183,18 +183,24 @@ class RecordFragment : Fragment() {
 
     private fun observingListen() {
         recordViewModel.isFirst.observe(viewLifecycleOwner) {
-            binding.btnRecordFirst.isChangeButtonFont(it)
-            binding.btnRecordSecond.isChangeButtonFont(!it)
+            Timber.d("collect!@!@ $it")
+            if (!it) {
+                binding.btnRecordFirst.isChangeButtonFont(it)
+                binding.btnRecordSecond.isChangeButtonFont(!it)
+                binding.btnRecordFirst.isEnabled = false
+            }
+            else{
+                binding.btnRecordFirst.isChangeButtonFont(!it)
+                binding.btnRecordSecond.isChangeButtonFont(it)
+            }
         }
     }
 
     private fun firstListenClickEvent() {
-        binding.btnRecordFirst.isChangeButtonFont(true)
         with(binding) {
             btnRecordFirst.setOnClickListener {
                 btnRecordFirst.isChangeButtonFont(true)
                 btnRecordSecond.isChangeButtonFont(false)
-                recordViewModel!!.checkIsFirst(true)
             }
         }
     }
@@ -204,7 +210,7 @@ class RecordFragment : Fragment() {
             binding.btnRecordSecond.setOnClickListener {
                 btnRecordFirst.isChangeButtonFont(false)
                 btnRecordSecond.isChangeButtonFont(true)
-                recordViewModel!!.checkIsFirst(false)
+
             }
         }
     }
@@ -273,8 +279,9 @@ class RecordFragment : Fragment() {
 
         recordViewModel.checkSelectedMusic(false)
 
-        binding.btnRecordFirst.isChangeButtonFont(true)
+        binding.btnRecordFirst.isChangeButtonFont(false)
         binding.btnRecordSecond.isChangeButtonFont(false)
+        binding.btnRecordFirst.isEnabled = true
         recordViewModel.checkIsFirst(true)
 
         binding.clRecordRoot.scrollTo(0, 0)
@@ -299,6 +306,7 @@ class RecordFragment : Fragment() {
         binding.btnRecordSearch.setOnClickListener {
             BottomSheetSearchFragment.newInstance {
                 recordViewModel.changeSelectedMusic(it)
+                recordViewModel.findIsFirst()
             }.show(parentFragmentManager, "bottom sheet")
             recordViewModel.checkSelectedMusic(true)
             Timber.d(recordViewModel.selectedMusic.value.toString())
@@ -306,14 +314,16 @@ class RecordFragment : Fragment() {
         recordViewModel.selectedMusic.observe(viewLifecycleOwner) {
             Timber.e("$it")
             recordViewModel.checkSelectedMusic(true)
+
         }
     }
 
 
     private fun getAllData() {
         binding.btnRecordFinish.setOnClickListener {
+
             Timber.e(
-                "버튼 : ${recordViewModel.isFirst.value}\n 태그 : ${
+                "버튼 : ${binding.btnRecordFirst.isSelected}\n 태그 : ${
                     rvImpressionTagsAdapter.selectedTags.map {
                         it.tagIdx
                     }
@@ -326,8 +336,14 @@ class RecordFragment : Fragment() {
         binding.ivDelete.setOnClickListener {
             recordViewModel.checkSelectedMusic(false)
             recordViewModel.removeSelectedMusic()
+            binding.btnRecordFirst.isEnabled =true
+            binding.btnRecordFirst.isChangeButtonFont(false)
+            binding.btnRecordSecond.isChangeButtonFont(false)
+
         }
     }
+
+
 
 
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/RecordFragment.kt
@@ -1,11 +1,14 @@
 package com.mument_android.app.presentation.ui.record
 
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.Button
 import android.widget.TextView
 import androidx.core.content.res.ResourcesCompat
@@ -23,7 +26,6 @@ import com.mument_android.app.domain.entity.TagEntity
 import com.mument_android.app.domain.entity.TagEntity.Companion.TAG_EMOTIONAL
 import com.mument_android.app.presentation.ui.customview.MumentDialogBuilder
 import com.mument_android.app.presentation.ui.home.BottomSheetSearchFragment
-import com.mument_android.app.presentation.ui.home.viewmodel.SearchViewModel
 import com.mument_android.app.presentation.ui.record.viewmodel.RecordViewModel
 import com.mument_android.app.util.AutoClearedValue
 import com.mument_android.app.util.RecyclerviewItemDivider
@@ -197,8 +199,8 @@ class RecordFragment : Fragment() {
     private fun firstListenClickEvent() {
         with(binding) {
             btnRecordFirst.setOnClickListener {
-                    btnRecordFirst.isChangeButtonFont(true)
-                    btnRecordSecond.isChangeButtonFont(false)
+                btnRecordFirst.isChangeButtonFont(true)
+                btnRecordSecond.isChangeButtonFont(false)
             }
             btnRecordFirst.setOnTouchListener { view, motionEvent ->
 
@@ -224,7 +226,6 @@ class RecordFragment : Fragment() {
         binding.switchRecordSecret.setOnClickListener {
             if (binding.switchRecordSecret.isChecked) {
                 binding.tvRecordSecret.setText(R.string.record_secret)
-
             } else {
                 binding.tvRecordSecret.setText(R.string.record_open)
             }
@@ -261,7 +262,15 @@ class RecordFragment : Fragment() {
     }
 
     private fun scrollEditTextView() {
+
         binding.etRecordWrite.movementMethod = ScrollingMovementMethod()
+        binding.etRecordWrite.setOnClickListener {
+            binding.svRecord.scrollTo(0, binding.tvRecordWriteTitle.top)
+        }
+
+        binding.etRecordWrite.setOnFocusChangeListener { view, b ->
+            binding.svRecord.scrollTo(0, binding.tvRecordWriteTitle.top)
+        }
     }
 
     private fun resetButtonClickEvent() {
@@ -323,6 +332,7 @@ class RecordFragment : Fragment() {
     private fun getAllData() {
         binding.btnRecordFinish.setOnClickListener {
             recordViewModel.postMument()
+
         }
     }
 

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
@@ -1,24 +1,31 @@
 package com.mument_android.app.presentation.ui.record.viewmodel
+
 import androidx.lifecycle.*
+import com.mument_android.BuildConfig
+import com.mument_android.app.data.dto.record.MumentRecordDto
 import com.mument_android.app.data.local.recentlist.RecentSearchData
 import com.mument_android.app.domain.entity.TagEntity
 import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCase
+import com.mument_android.app.domain.usecase.record.RecordMumentUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCase) : ViewModel() {
+class RecordViewModel @Inject constructor(
+    private val checkIsFirstRecordUseCase: IsFirstRecordMumentUseCase,
+    private val recordMumentUseCase: RecordMumentUseCase
+) : ViewModel() {
     private val _checkedTagList = MutableLiveData<List<TagEntity>>(listOf())
     val checkedTagList get():LiveData<List<TagEntity>> = _checkedTagList
 
     private val _isFirst = MutableLiveData<Boolean>()
     val isFirst get() :LiveData<Boolean> = _isFirst
-    val text = MutableLiveData<String>()
 
+    val mumentContent = MutableLiveData<String>()
 
     private val _isSelectedMusic = MutableLiveData<Boolean>(false)
     val isSelectedMusic get(): LiveData<Boolean> = _isSelectedMusic
@@ -26,14 +33,33 @@ class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCas
     private val _selectedMusic = MutableLiveData<RecentSearchData>()
     val selectedMusic = _selectedMusic
 
+    private val _createdMumentId = MutableLiveData<String>("")
+    val createdMumentId = _createdMumentId
+
+    var isPrivate = MutableLiveData<Boolean>(false)
+
 //    val data = SearchResultData("25", "불꽃카리스마", "이민호","https://cdnimg.melon.co.kr/cm2/album/images/107/10/311/10710311_20210909184021_500.jpg?6513495083f58ce168a24189a1edb874/melon/resize/282/quality/80/optimize",true)
 
     fun findIsFirst() {
         viewModelScope.launch {
-            useCase.invoke( "62cd5d4383956edb45d7d0ef","62cd4416177f6e81ee8fa398").onStart {
+            checkIsFirstRecordUseCase.invoke("62cd5d4383956edb45d7d0ef", "62cd4416177f6e81ee8fa398").onStart {
             }.collect {
-                Timber.d("Collect!!! $it")
                 _isFirst.value = it.isFirst
+            }
+        }
+    }
+
+    fun postMument() {
+        viewModelScope.launch {
+            checkedTagList.value?.let { tags ->
+                val feelingTags = tags.filter { it.tagIdx >= 200 }.map { it.tagIdx }
+                val impressionTags = tags.filter { it.tagIdx < 200 }.map { it.tagIdx }
+                val recordDto = MumentRecordDto(content = mumentContent.value ?: "", feelingTags, impressionTags, isFirst.value ?: true, isPrivate.value ?: false)
+                recordMumentUseCase(musicId = "62d2959e177f6e81ee8fa3de", userId = BuildConfig.USER_ID, recordDto).catch { e ->
+                    e.printStackTrace()
+                }.collect {
+                    _createdMumentId.value = it
+                }
             }
         }
     }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
@@ -1,21 +1,24 @@
 package com.mument_android.app.presentation.ui.record.viewmodel
-
-
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.*
 import com.mument_android.app.data.local.recentlist.RecentSearchData
 import com.mument_android.app.domain.entity.TagEntity
-import com.mument_android.app.domain.entity.musicdetail.MusicDetailEntity
+import com.mument_android.app.domain.usecase.record.IsFirstRecordMumentUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
 
-
-class RecordViewModel : ViewModel() {
+@HiltViewModel
+class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCase) : ViewModel() {
     private val _checkedTagList = MutableLiveData<List<TagEntity>>(listOf())
     val checkedTagList get():LiveData<List<TagEntity>> = _checkedTagList
 
-    private val _isFirst = MutableLiveData<Boolean>()
+    private val _isFirst = MutableLiveData<Boolean>(true)
     val isFirst get() :LiveData<Boolean> = _isFirst
     val text = MutableLiveData<String>()
+
 
     private val _isSelectedMusic = MutableLiveData<Boolean>()
     val isSelectedMusic get(): LiveData<Boolean> = _isSelectedMusic
@@ -24,6 +27,17 @@ class RecordViewModel : ViewModel() {
     val selectedMusic = _selectedMusic
 
 //    val data = SearchResultData("25", "불꽃카리스마", "이민호","https://cdnimg.melon.co.kr/cm2/album/images/107/10/311/10710311_20210909184021_500.jpg?6513495083f58ce168a24189a1edb874/melon/resize/282/quality/80/optimize",true)
+
+    fun findIsFirst() {
+        viewModelScope.launch {
+            useCase.invoke( "62cd5d4383956edb45d7d0ef","62cd4416177f6e81ee8fa398").onStart {
+
+            }.collect {
+                Timber.d("Collect!!! $it")
+                _isFirst.value = it.isFirst
+            }
+        }
+    }
 
     fun changeSelectedMusic(music: RecentSearchData) {
         _selectedMusic.value = music
@@ -56,10 +70,12 @@ class RecordViewModel : ViewModel() {
         _isFirst.value = isFirst
     }
 
-    fun checkSelectedMusic(isSelected : Boolean) {
+    fun checkSelectedMusic(isSelected: Boolean) {
         _isSelectedMusic.value = isSelected
+        findIsFirst()
     }
-    fun removeSelectedMusic(){
+
+    fun removeSelectedMusic() {
         selectedMusic.value = null
         _isSelectedMusic.value = false
     }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/record/viewmodel/RecordViewModel.kt
@@ -15,12 +15,12 @@ class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCas
     private val _checkedTagList = MutableLiveData<List<TagEntity>>(listOf())
     val checkedTagList get():LiveData<List<TagEntity>> = _checkedTagList
 
-    private val _isFirst = MutableLiveData<Boolean>(true)
+    private val _isFirst = MutableLiveData<Boolean>()
     val isFirst get() :LiveData<Boolean> = _isFirst
     val text = MutableLiveData<String>()
 
 
-    private val _isSelectedMusic = MutableLiveData<Boolean>()
+    private val _isSelectedMusic = MutableLiveData<Boolean>(false)
     val isSelectedMusic get(): LiveData<Boolean> = _isSelectedMusic
 
     private val _selectedMusic = MutableLiveData<RecentSearchData>()
@@ -31,7 +31,6 @@ class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCas
     fun findIsFirst() {
         viewModelScope.launch {
             useCase.invoke( "62cd5d4383956edb45d7d0ef","62cd4416177f6e81ee8fa398").onStart {
-
             }.collect {
                 Timber.d("Collect!!! $it")
                 _isFirst.value = it.isFirst
@@ -50,7 +49,6 @@ class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCas
             tempList.add(tag)
             _checkedTagList.value = tempList
         }
-
     }
 
     fun removeCheckedList(tag: TagEntity) {
@@ -72,7 +70,6 @@ class RecordViewModel @Inject constructor(val useCase: IsFirstRecordMumentUseCas
 
     fun checkSelectedMusic(isSelected: Boolean) {
         _isSelectedMusic.value = isSelected
-        findIsFirst()
     }
 
     fun removeSelectedMusic() {

--- a/app/src/main/res/layout/fragment_record.xml
+++ b/app/src/main/res/layout/fragment_record.xml
@@ -290,7 +290,7 @@
                             android:paddingHorizontal="13dp"
                             android:scrollbarStyle="insideInset"
                             android:scrollbars="vertical"
-                            android:text="@={recordViewModel.text}"
+                            android:text="@={recordViewModel.mumentContent}"
                             android:textColor="@color/mument_color_black2"
                             android:textColorHint="@color/mument_color_gray1" />
                     </androidx.core.widget.NestedScrollView>
@@ -302,7 +302,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginEnd="13dp"
                         android:layout_marginBottom="15dp"
-                        android:text="@{@string/record_text_num(recordViewModel.text.length())}"
+                        android:text="@{@string/record_text_num(recordViewModel.mumentContent.length())}"
                         android:textColor="@color/mument_color_gray2"
                         app:layout_constraintBottom_toBottomOf="@+id/cl_record_write"
                         app:layout_constraintEnd_toEndOf="@+id/ns_record_write"
@@ -328,7 +328,7 @@
                     android:layout_marginTop="15dp"
                     android:layout_marginEnd="16dp"
                     android:layout_marginBottom="160dp"
-                    android:checked="false"
+                    android:checked="@={recordViewModel.isPrivate()}"
                     android:gravity="center"
                     android:thumb="@drawable/oval_fill_white"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -130,8 +130,14 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rc_search"
                     android:layout_width="match_parent"
+<<<<<<< HEAD
                     android:layout_height="0dp"
                     android:layout_weight="1"
+=======
+                    android:layout_height="match_parent"
+                    android:nestedScrollingEnabled="false"
+                    android:overScrollMode="never"
+>>>>>>> 778d4b0 (Mument Dialog 수정)
                     android:visibility="@{viewmodel.searchList.data.size() == 0 ? View.GONE : View.VISIBLE}"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -130,14 +130,10 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rc_search"
                     android:layout_width="match_parent"
-<<<<<<< HEAD
                     android:layout_height="0dp"
                     android:layout_weight="1"
-=======
-                    android:layout_height="match_parent"
                     android:nestedScrollingEnabled="false"
                     android:overScrollMode="never"
->>>>>>> 778d4b0 (Mument Dialog 수정)
                     android:visibility="@{viewmodel.searchList.data.size() == 0 ? View.GONE : View.VISIBLE}"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 🎸 작업한 내용
- 기록하기 뷰 Api 를 구현하였습니다. (처음들어요/다시들었어요, 기록하기)

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

1. MumentDialog 에서 확인과 삭제 둘다 들어가는 경우가 있어서 option 으로 수정해주었습니다.!

```kotlin
override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
    super.onViewCreated(view, savedInstanceState)
    binding.tvHeader.setContent(header)
    binding.tvBody.setContent(body)
    binding.tvAllow.text= if(option) "확인" else "삭제"
    setClickListener()
}
```
코드에서 아래와 같이 setOption() 넣어주시면 됩니다. true 일땐 '확인', false 일땐 '삭제' 입니다.!
```kotlin
 MumentDialogBuilder()
            .setHeader(getString(R.string.record_reset_header))
            .setBody(getString(R.string.record_reset_body))
            .setOption(true)
            .setAllowListener {
                resetRecord()
                resetRecordTags()
            }
            .setCancelListener {}
            .build()
            .show(childFragmentManager, this.tag)
```

2. 처음들어요,다시들었어요 버튼, api 구현

-  검색하기를 눌렀을 때 나오는 리스트를 누르면 받아온 유저의 정보에 따라 바로 '다시들었어요'로 버튼이 구현되게 하였습니다.! ( 리셋버튼이나 곡 선택 부분의 x 버튼 누르면 버튼 초기화상태로 구현하였습니다.)
- 기록하기 뷰 처음 들어왔을 때에는 처음들어요,다시들었어요 버튼 초기화로 UI 변경 되어서 구현해주었습니다. 마이노 최고~!

3. 기록하기 Api 구현4. 
-평화아빠와 함께 기록하기 api 연결 구현하였습니다. 나중에 검색 부분과 연결해서 music id 값 연결해 줄 예정입니다. 아빠 최고~!

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 💽 관련 이슈
- Resolved: #66 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
