### PR TITLE
#273 [FIX] Interceptor 로직 개선

### DIFF
--- a/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/mument_android/app/di/NetworkModule.kt
@@ -40,7 +40,6 @@ object NetworkModule {
     @Singleton
     fun provideErrorHandler(): ErrorHandler = ErrorHandlerImpl()
 
-
     @Provides
     @Singleton
     fun provideLoggingInterceptor(): HttpLoggingInterceptor =
@@ -162,9 +161,4 @@ object NetworkModule {
     @Singleton
     fun provideRefreshTokenApiService(@UnAuthRetrofit retrofit: Retrofit): RefreshTokenApiService =
         retrofit.create()
-
-    private fun Request.Builder.addHeaders(token: String) =
-        this.apply { header("Authorization", "Bearer $token") }
-
-    private const val BEARER = "Bearer"
 }

--- a/app/src/main/java/com/mument_android/app/presentation/ui/detail/mument/navigator/LogInNavigatorProviderImpl.kt
+++ b/app/src/main/java/com/mument_android/app/presentation/ui/detail/mument/navigator/LogInNavigatorProviderImpl.kt
@@ -3,6 +3,8 @@ package com.mument_android.app.presentation.ui.detail.mument.navigator
 import android.content.Context
 import android.content.Intent
 import com.angdroid.navigation.LogInNavigatorProvider
+import com.mument_android.SplashActivity
+import com.mument_android.core_dependent.ext.getTopActivity
 import com.mument_android.login.LogInActivity
 import javax.inject.Inject
 
@@ -10,11 +12,13 @@ class LogInNavigatorProviderImpl @Inject constructor(
     private val context: Context
 ): LogInNavigatorProvider {
     override fun navToLogin() {
-        Intent(context, LogInActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                    Intent.FLAG_ACTIVITY_CLEAR_TASK or
-                    Intent.FLAG_ACTIVITY_NEW_TASK
-            context.startActivity(this)
+        if (context.getTopActivity() != SplashActivity::class.java.simpleName) {
+            Intent(context, LogInActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                        Intent.FLAG_ACTIVITY_NEW_TASK
+                context.startActivity(this)
+            }
         }
     }
 }

--- a/core_dependent/src/main/java/com/mument_android/core_dependent/ext/ViewExtensions.kt
+++ b/core_dependent/src/main/java/com/mument_android/core_dependent/ext/ViewExtensions.kt
@@ -1,7 +1,8 @@
 package com.mument_android.core_dependent.ext
 
-import android.app.Activity
 import android.app.Activity.RESULT_OK
+import android.app.ActivityManager
+import android.content.Context
 import android.content.Intent
 import android.util.TypedValue
 import android.view.View
@@ -9,16 +10,15 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.databinding.BindingAdapter
 import androidx.fragment.app.FragmentActivity
 import com.mument_android.core.model.TagEntity.Companion.TAG_IS_FIRST
-import com.mument_android.core_dependent.util.ViewUtils.dpToPx
 import com.mument_android.core_dependent.R
 import com.mument_android.core_dependent.util.OnSingleClickListener
+import com.mument_android.core_dependent.util.ViewUtils.dpToPx
 
 inline fun View.click(crossinline block: () -> Unit) {
     setOnClickListener { block() }
@@ -47,6 +47,21 @@ inline fun FragmentActivity.getActivityResult(crossinline resultSuccess: (Intent
     }
 }
 
+fun Context.getTopActivity(): String {
+    return try {
+        val activityManager = getSystemService(ActivityManager::class.java)
+        val list = activityManager.appTasks
+        if (list.isEmpty() || list[0].taskInfo.topActivity == null) {
+            ""
+        } else {
+            val topClassName = list[0].taskInfo.topActivity?.className ?: ""
+            val lastIndex = topClassName.lastIndexOf(".") + 1
+            topClassName.substring(lastIndex)
+        }
+    } catch (e: Exception) {
+        ""
+    }
+}
 
 object BindingExtension{
 

--- a/feature/home/src/main/java/com/mument_android/home/main/HomeFragment.kt
+++ b/feature/home/src/main/java/com/mument_android/home/main/HomeFragment.kt
@@ -97,7 +97,6 @@ class HomeFragment : Fragment() {
         receiveEffect()
         binding.tvSearch.setOnClickListener {
             viewModel.emitEvent(HomeEvent.OnClickSearch)
-
         }
         binding.ivNotify.setOnClickListener {
             viewModel.emitEvent(HomeEvent.OnClickNotification)

--- a/feature/login/src/main/java/com/mument_android/SplashActivity.kt
+++ b/feature/login/src/main/java/com/mument_android/SplashActivity.kt
@@ -2,9 +2,6 @@ package com.mument_android
 
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.angdroid.navigation.MainHomeNavigatorProvider
@@ -15,6 +12,7 @@ import com.mument_android.login.LogInViewModel
 import com.mument_android.login.databinding.ActivitySplashBinding
 import com.mument_android.onboarding.OnBoardingActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -37,30 +35,27 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(ActivitySplashBinding
 
     //스플래시 -> 우선은 로그인으로 가는 로직 (후에 토큰 관리하다보면 login or main 분기처리)
     private fun initSplash() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            isFirst()
-        }, DURATION)
-    }
-
-    private fun isFirst() {
         lifecycleScope.launch {
+            delay(DURATION)
             if (dataStoreManager.isFirstFlow.firstOrNull() == null) {
-                Log.e("datastore", "onBoarding")
                 val intent = Intent(this@SplashActivity, OnBoardingActivity::class.java)
                 startActivity(intent)
                 finish()
             } else {
+                viewModel.isExistProfile()
                 if (dataStoreManager.isFirstFlow.firstOrNull() == false) {
                     dataStoreManager.writeIsFirst(true)
                 }
-                viewModel.isExistProfile()
                 viewModel.isExist.collectLatest { exist ->
-                    Log.e("Why?", exist.toString())
                     if (exist == true) {
                         moveToMainActivity()
                         finish()
                     } else if (exist == false) {
-                        val intent = Intent(this@SplashActivity, LogInActivity::class.java)
+                        val intent = Intent(this@SplashActivity, LogInActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                                    Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                                    Intent.FLAG_ACTIVITY_NEW_TASK
+                        }
                         startActivity(intent)
                         finish()
                     }

--- a/feature/login/src/main/java/com/mument_android/login/LogInActivity.kt
+++ b/feature/login/src/main/java/com/mument_android/login/LogInActivity.kt
@@ -51,41 +51,6 @@ class LogInActivity : BaseActivity<ActivityLogInBinding>(ActivityLogInBinding::i
         //keyClipBoard()
     }
 
-    /*
-    private fun keyClipBoard() {
-        var keyHash = Utility.getKeyHash(this)
-        Log.e("kkkkkkkkkk:", "$keyHash")
-        binding.key.setText("$keyHash")
-        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-
-        // 새로운 ClipData 객체로 데이터 복사하기
-        val clip: ClipData =
-            ClipData.newPlainText("simple text", binding.key.text.toString())
-
-        // 새로운 클립 객체를 클립보드에 배치합니다.
-        clipboard.setPrimaryClip(clip)
-
-        Toast.makeText(this, "복사 완료.", Toast.LENGTH_SHORT).show()
-        false
-
-        binding.key.setOnClickListener {
-            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-
-            // 새로운 ClipData 객체로 데이터 복사하기
-            val clip: ClipData =
-                ClipData.newPlainText("simple text", binding.key.text.toString())
-
-            // 새로운 클립 객체를 클립보드에 배치합니다.
-            clipboard.setPrimaryClip(clip)
-
-            Toast.makeText(this, "복사 완료.", Toast.LENGTH_SHORT).show()
-            false
-        }
-    }
-
-     */
-
-
     private fun getFcmToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
             if (!task.isSuccessful) {  //기기 토큰 얻어오는 코드


### PR DESCRIPTION
## 🎸 작업한 내용
- Interceptor 토큰 갱신 하는 부분이 애매해서 로직 변경하였습니다.
- LogInNavigatorProvider 사용 -> 로그인 화면으로 이동 시에 Splash 에서도 이동하기 때문에 해당 부분 걸러주는 getTopActivity 확장함수 생성
- 로직 변경 내역
  - Access Token으로 요청
  - 실패 시 Refresh 토큰으로 토큰 갱신 시도
  - 갱신 성공하면 Access, Refresh 최신화
  - 갱신 실패하면 2번 더 도전해보고 토큰 만료 로직
  - 토큰 만료 로직으로 Login 화면으로 이동(Splash 에서도 이동하기 때문에 걸러줌)
- Splash 로직 Handler -> Coroutine 으로 변경

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 예상가는 SideEffect 있을 지 체크해주세요!
- #271 은 이거 먼저 머지 해야 오류가 안 생깁니다!

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
- 딱히,,? 뭐 없슴
- 이전에는 화면에 머문 상태에서 만료 되면 그대로 데이터 못 불러오는데 지금은 로그인 화면으로 이동하게 했음(이 케이스는 웬만하면 없긴함)

## 💽 관련 이슈
- Resolved: #273 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
